### PR TITLE
Reimplement TCP_NODELAY.

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/accept.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/accept.c
@@ -60,6 +60,7 @@ bool tcp_accept(tcp_socket_t* socket, bool client_blocking, int* out_clientfd, n
             .socket = client,
             .socket_pollable = client_pollable,
             .blocking = client_blocking,
+            .fake_nodelay = socket->fake_nodelay,
             .state_tag = TCP_SOCKET_STATE_CONNECTED,
             .state = { .connected = {
                 .input = input,

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/socket.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/socket.c
@@ -22,6 +22,7 @@ int tcp_socket(network_ip_address_family_t family, bool blocking)
             .socket = socket,
             .socket_pollable = socket_pollable,
             .blocking = blocking,
+            .fake_nodelay = false,
             .state_tag = TCP_SOCKET_STATE_UNBOUND,
             .state = { .unbound = { /* No additional state. */ } },
         } },

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/sockopt.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/sockopt.c
@@ -167,6 +167,10 @@ int tcp_getsockopt(tcp_socket_t* socket, int level, int optname,
 
     case SOL_TCP:
         switch (optname) {
+        case TCP_NODELAY: {
+            value = socket->fake_nodelay;
+            break;
+        }
         case TCP_KEEPIDLE: {
             tcp_duration_t result_ns;
             if (!tcp_method_tcp_socket_keep_alive_idle_time(socket_borrow, &result_ns, &error)) {
@@ -352,15 +356,18 @@ int tcp_setsockopt(tcp_socket_t* socket, int level, int optname, const void* opt
     case SOL_TCP:
         switch (optname) {
         case TCP_NODELAY: {
-            if (intval == 0) {
-                errno = EDOM;
-                return -1;
-            } else {
-                // Do nothing -- WASI sockets always have no-delay enabled.
-                return 0;
-            }
+            // At the time of writing, WASI has no support for TCP_NODELAY.
+            // Yet, many applications expect this option to be implemented.
+            // To ensure those applications can run on WASI at all, we fake
+            // support for it by recording the value, but not doing anything
+            // with it.
+            // If/when WASI adds true support, we can remove this workaround
+            // and implement it properly. From the application's perspective
+            // the "worst" thing that can then happen is that it automagically
+            // becomes faster.
+            socket->fake_nodelay = (intval != 0);
+            return 0;
         }
-
         case TCP_KEEPIDLE: {
             tcp_duration_t duration = intval * NS_PER_S;
             if (!tcp_method_tcp_socket_set_keep_alive_idle_time(socket_borrow, duration, &error)) {

--- a/libc-bottom-half/headers/private/descriptor_table.h
+++ b/libc-bottom-half/headers/private/descriptor_table.h
@@ -41,6 +41,7 @@ typedef struct {
     tcp_own_tcp_socket_t socket;
     poll_own_pollable_t socket_pollable;
     bool blocking;
+    bool fake_nodelay;
     tcp_socket_state_tag_t state_tag;
     tcp_socket_state_t state;
 } tcp_socket_t;


### PR DESCRIPTION
To answer your [question](https://github.com/dicej/wasi-libc/pull/2#pullrequestreview-1768463193):
> how should TCP_NODELAY be handled? Many applications use it and will choke if it doesn't work. I assume it was removed from wasi-sockets because it's always enabled there? If so, can we make setsockopt support "enabling" it as a no-op and only return an error if someone tries to disable it?

Not quite. WASI doesn't enable TCP_DELAY by default. Regardless, I think your solution of handling it fully in libc for now should work fine.
If/when WASI adds support for TCP_NODELAY, the "worst" thing that can then happen is that applications who had enabled TCP_NODELAY suddenly become even faster.

---

Some background (co-written by ChatGPT):
> By default, TCP tries to improve network efficiency by delaying the transmission of small packets and combining them into larger ones before sending. By accumulating and sending data in larger chunks, it reduces the number of packets sent over the network, which can improve overall network utilization and reduce congestion. However, this delay in sending small amounts of data can introduce a small latency between the last `send` and the moment the data is actually put on the wire.

Enabling TCP_NODELAY bypasses this behavior. And as a consequence this also moves the responsibility of emitting properly sized `send`s up to the application. This is why WASI can't just enable it by default.

